### PR TITLE
fix: add missing Msg() to zerolog call in EditKeywordHandler

### DIFF
--- a/pkg/handler/commands_handler.go
+++ b/pkg/handler/commands_handler.go
@@ -104,7 +104,7 @@ func (c *CommandsHandler) EditKeywordHandler(ctx context.Context, b *bot.Bot, up
 			ChatID: update.Message.Chat.ID,
 			Text:   fmt.Sprintf("%s: successful.", constant.EditKeyword),
 		}); msgErr != nil {
-			c.ctx.Logger.Error().Err(msgErr)
+			c.ctx.Logger.Error().Stack().Err(msgErr).Msg("send edit keyword message failed")
 		}
 	} else {
 		if _, msgErr := b.SendMessage(ctx, &bot.SendMessageParams{


### PR DESCRIPTION
**问题**：`c.ctx.Logger.Error().Err(msgErr)` 后面没接 `.Msg()`，zerolog 事件永远不会输出，编辑关键词失败的错误被静默丢弃。

**修复**：补上 `.Stack().Err(msgErr).Msg(...)`。