### PR TITLE
fix: correct sync.Pool usage in ComplexRule.MarshalJSON

### DIFF
--- a/pkg/rule/complex_rule.go
+++ b/pkg/rule/complex_rule.go
@@ -88,16 +88,21 @@ var slicePool = sync.Pool{
 }
 
 func (cr *ComplexRule) MarshalJSON() ([]byte, error) {
+	include := keysToSlice(cr.IncludeTerms)
+	exclude := keysToSlice(cr.ExcludeTerms)
+	// Put the exact same slices back that were used for marshaling, otherwise
+	// the pooled slices are never reused and concurrent MarshalJSON calls can
+	// race on the same underlying slice.
+	defer slicePool.Put(include)
+	defer slicePool.Put(exclude)
+
 	temp := struct {
 		IncludeTerms []string `json:"includeTerms"`
 		ExcludeTerms []string `json:"excludeTerms"`
 	}{
-		IncludeTerms: *keysToSlice(cr.IncludeTerms),
-		ExcludeTerms: *keysToSlice(cr.ExcludeTerms),
+		IncludeTerms: *include,
+		ExcludeTerms: *exclude,
 	}
-
-	defer slicePool.Put(keysToSlice(cr.IncludeTerms))
-	defer slicePool.Put(keysToSlice(cr.ExcludeTerms))
 
 	return json.Marshal(temp)
 }


### PR DESCRIPTION
**问题**：`MarshalJSON` 里 defer 又调用了一次 `keysToSlice()`，从池里重新 Get slice 而不是归还真正用于序列化的 slice。结果：
- 实际使用的两个 slice 从不归还池中
- 并发 MarshalJSON 时可能从池中拿到同一个 slice 互踩（data race）

**修复**：先取 slice 保存引用，defer 归还的是同一份。