### PR TITLE
fix: secure PDF/IMG webhook endpoint with token auth and limits

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ import (
 type PDFServiceConfig struct {
 	WebhookServer     string
 	WebhookServerPort int
+	WebhookToken      string
 	PDFServiceURL     string
 }
 
@@ -27,6 +28,7 @@ func (c *PDFServiceConfig) Init() *PDFServiceConfig {
 	if v := os.Getenv(constant.WebhookServerPort); v != "" {
 		c.WebhookServerPort, _ = strconv.Atoi(v)
 	}
+	c.WebhookToken = os.Getenv(constant.WebhookToken)
 	return c
 }
 

--- a/pkg/constant/server.go
+++ b/pkg/constant/server.go
@@ -18,6 +18,7 @@ const (
 	PDFEndPoint       = "/pdf/"
 	WebhookServerURL  = "WEBHOOK_SERVER_URL"
 	WebhookServerPort = "WEBHOOK_SERVER_PORT"
+	WebhookToken      = "WEBHOOK_TOKEN"
 	PDFServerUrl      = "PDF_SERVER_URL"
 	PDFExtension      = ".pdf"
 	ImgExtension      = ".png"

--- a/pkg/handler/bot_context.go
+++ b/pkg/handler/bot_context.go
@@ -101,7 +101,7 @@ func NewBotContext() (*BotContext, error) {
 	}
 	dal.SetDefault(db)
 	// init gotenberg
-	client, err := NewGotenbergClient(cfg.PDF.PDFServiceURL, cfg.PDF.WebhookURL())
+	client, err := NewGotenbergClient(cfg.PDF.PDFServiceURL, cfg.PDF.WebhookURL(), cfg.PDF.WebhookToken)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gotenberg client: %s", err)
 	}

--- a/pkg/handler/gotenberg.go
+++ b/pkg/handler/gotenberg.go
@@ -17,17 +17,23 @@ const fname = "index.html"
 type GotenbergClient struct {
 	client  *gotenberg.Client
 	hookURL string
+	token   string
 }
 
-func NewGotenbergClient(host string, hookURL string) (*GotenbergClient, error) {
+func NewGotenbergClient(host string, hookURL string, token string) (*GotenbergClient, error) {
 	if client, err := gotenberg.NewClient(host, http.DefaultClient); err == nil {
 		return &GotenbergClient{
 			client:  client,
 			hookURL: hookURL,
+			token:   token,
 		}, nil
 	} else {
 		return nil, err
 	}
+}
+
+func (g *GotenbergClient) webhookToken() string {
+	return g.token
 }
 
 func (g *GotenbergClient) URLToPDF(u string) (string, error) {
@@ -35,6 +41,9 @@ func (g *GotenbergClient) URLToPDF(u string) (string, error) {
 	req.SetWebhookMethod(http.MethodPost)
 	requestId := uuid.New().String()
 	hookURL := fmt.Sprintf("%s%s%s", g.hookURL, constant.PDFEndPoint, requestId)
+	if token := g.webhookToken(); token != "" {
+		hookURL = fmt.Sprintf("%s?token=%s", hookURL, token)
+	}
 	req.UseWebhook(hookURL, hookURL)
 
 	if resp, err := g.client.Send(context.Background(), req); err == nil {
@@ -58,6 +67,9 @@ func (g *GotenbergClient) HtmlToImage(content string) (string, error) {
 
 	requestId := uuid.New().String()
 	hookURL := fmt.Sprintf("%s%s%s", g.hookURL, constant.PDFEndPoint, requestId)
+	if token := g.webhookToken(); token != "" {
+		hookURL = fmt.Sprintf("%s?token=%s", hookURL, token)
+	}
 	req := gotenberg.NewHTMLRequest(index)
 	req.ScreenshotOptimizeForSpeed()
 	req.SetWebhookMethod(http.MethodPost)
@@ -79,6 +91,9 @@ func (g *GotenbergClient) HtmlToImage(content string) (string, error) {
 func (g *GotenbergClient) URLToImage(u string) (string, error) {
 	requestId := uuid.New().String()
 	hookURL := fmt.Sprintf("%s%s%s", g.hookURL, constant.PDFEndPoint, requestId)
+	if token := g.webhookToken(); token != "" {
+		hookURL = fmt.Sprintf("%s?token=%s", hookURL, token)
+	}
 	req := gotenberg.NewURLRequest(u)
 	req.EmulateScreenMediaType()
 	req.SetWebhookMethod(http.MethodPost)

--- a/pkg/handler/webhook_handler.go
+++ b/pkg/handler/webhook_handler.go
@@ -12,21 +12,34 @@ import (
 	"github.com/gythialy/magnet/pkg/model"
 )
 
+const (
+	webhookMaxBodyBytes = 20 << 20 // 20MB, matching Telegram document upload limit
+	webhookMaxWorkers   = 10
+)
+
 type webhooker struct {
-	ctx *BotContext
+	ctx     *BotContext
+	sem     chan struct{}
 }
 
 func newWebhooker(ctx *BotContext) *webhooker {
-	return &webhooker{ctx: ctx}
+	return &webhooker{ctx: ctx, sem: make(chan struct{}, webhookMaxWorkers)}
 }
 
 func (wh *webhooker) WebhookHandler(w http.ResponseWriter, r *http.Request) {
+	// Reject requests without a valid token when one is configured
+	if token := wh.ctx.Config.PDF.WebhookToken; token != "" && r.URL.Query().Get("token") != token {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
 	requestID := r.URL.Path[len(constant.PDFEndPoint):]
 
+	r.Body = http.MaxBytesReader(w, r.Body, webhookMaxBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		wh.ctx.Logger.Error().Stack().Err(err).Msg("")
-		http.Error(w, "Failed to read body", http.StatusInternalServerError)
+		http.Error(w, "Failed to read body", http.StatusBadRequest)
 		return
 	}
 
@@ -34,8 +47,20 @@ func (wh *webhooker) WebhookHandler(w http.ResponseWriter, r *http.Request) {
 		wh.ctx.Logger.Error().Msg("Chat ID not found for request")
 		http.Error(w, "Chat ID not found", http.StatusNotFound)
 	} else {
-		req := ri.(model.RequestInfo)
+		req, ok := ri.(model.RequestInfo)
+		if !ok {
+			wh.ctx.Logger.Error().Interface("stored", ri).Msg("unexpected type in store")
+			http.Error(w, "Invalid request state", http.StatusInternalServerError)
+			return
+		}
 		go func(req model.RequestInfo, data []byte) {
+			select {
+			case wh.sem <- struct{}{}:
+				defer func() { <-wh.sem }()
+			default:
+				wh.ctx.Logger.Warn().Msg("webhook worker pool full, dropping request")
+				return
+			}
 			switch req.Type {
 			case model.PDF:
 				// delete the processing message


### PR DESCRIPTION
**问题**：webhook 端点无鉴权，任何能访问该端口的人 POST `/pdf/<任意id>` 都能触发 bot 给对应 chat 发文件；body 无大小限制；goroutine 无上限；Store 类型断言可能 panic。

**修复**：
- 新增 `WEBHOOK_TOKEN` 环境变量，gotenberg 回调 URL 携带 token query 参数，handler 校验
- 未配置 token 时保持向后兼容（行为不变）
- body 上限 20MB（`http.MaxBytesReader`）
- 信号量限制并发 webhook worker（10）
- `req.(model.RequestInfo)` 加 ok 断言