### PR TITLE
perf: cache alarm detail fetches by noticeId within a run

### DIFF
--- a/pkg/handler/crawler.go
+++ b/pkg/handler/crawler.go
@@ -171,12 +171,16 @@ func (c *Crawler) alarm(noticeId string) (*model.AlarmDetail, error) {
 
 func (c *Crawler) Alarms(keywords []string, userId int64) []*model.Alarm {
 	result := make([]*model.Alarm, 0)
+	// Cache alarm detail fetches by noticeId. Multiple alarms often share the
+	// same notice (origin notice id), and breakFaith/suspend lists overlap,
+	// so without a cache the same detail endpoint gets hit N+1 times.
+	detailCache := make(map[string]*model.AlarmDetail)
 	r1 := c.alarmListByKeywords(keywords, constant.CreditTypeBreakFaith)
 	cache := make(map[string]interface{})
 	for _, alarm := range r1 {
 		if _, ok := cache[alarm.CreditCode]; !ok {
 			alarm.UserID = userId
-			c.alarmTitle(alarm)
+			c.alarmTitle(alarm, detailCache)
 			cache[alarm.CreditCode] = alarm
 			result = append(result, alarm)
 		}
@@ -185,7 +189,7 @@ func (c *Crawler) Alarms(keywords []string, userId int64) []*model.Alarm {
 	for _, alarm := range r2 {
 		if _, ok := cache[alarm.CreditCode]; !ok {
 			alarm.UserID = userId
-			c.alarmTitle(alarm)
+			c.alarmTitle(alarm, detailCache)
 			cache[alarm.CreditCode] = alarm
 			result = append(result, alarm)
 		}
@@ -193,8 +197,8 @@ func (c *Crawler) Alarms(keywords []string, userId int64) []*model.Alarm {
 	return result
 }
 
-func (c *Crawler) alarmTitle(alarm *model.Alarm) {
-	if detail, err := c.alarm(alarm.NoticeID); err == nil {
+func (c *Crawler) alarmTitle(alarm *model.Alarm, detailCache map[string]*model.AlarmDetail) {
+	if detail, err := c.alarmCached(alarm.NoticeID, detailCache); err == nil {
 		alarm.Title = &detail.Data.Title
 		u := fmt.Sprintf("https://%s%s", c.ctx.Config.MessageServerUrl, detail.Data.Pageurl)
 		alarm.PageUrl1 = u
@@ -202,13 +206,27 @@ func (c *Crawler) alarmTitle(alarm *model.Alarm) {
 		c.ctx.Logger.Error().Stack().Err(err).Msg("")
 	}
 	if alarm.OriginNoticeID != nil && *alarm.OriginNoticeID != "" {
-		if detail, err := c.alarm(*alarm.OriginNoticeID); err == nil {
+		if detail, err := c.alarmCached(*alarm.OriginNoticeID, detailCache); err == nil {
 			u := fmt.Sprintf("https://%s%s", c.ctx.Config.MessageServerUrl, detail.Data.Pageurl)
 			alarm.PageUrl2 = &u
 		} else {
 			c.ctx.Logger.Error().Stack().Err(err).Msg("")
 		}
 	}
+}
+
+// alarmCached fetches an alarm detail once per Process() run and reuses it
+// for every alarm that references the same noticeId.
+func (c *Crawler) alarmCached(noticeId string, detailCache map[string]*model.AlarmDetail) (*model.AlarmDetail, error) {
+	if detail, ok := detailCache[noticeId]; ok {
+		return detail, nil
+	}
+	detail, err := c.alarm(noticeId)
+	if err != nil {
+		return nil, err
+	}
+	detailCache[noticeId] = detail
+	return detail, nil
 }
 
 func (c *Crawler) format(time time.Time) string {

--- a/pkg/handler/crawler_test.go
+++ b/pkg/handler/crawler_test.go
@@ -10,18 +10,26 @@ import (
 
 	"github.com/gythialy/magnet/pkg/dal"
 	"github.com/gythialy/magnet/pkg/model"
+	"github.com/gythialy/magnet/pkg/utils"
 
 	"github.com/glebarez/sqlite"
+	"github.com/rs/zerolog"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
 
-func TestCrawler_Get(t *testing.T) {
-	crawler := NewCrawler(&BotContext{
+func testBotContext(serverUrl string) *BotContext {
+	nopLogger := zerolog.Nop()
+	return &BotContext{
+		Logger: &utils.Logger{Logger: &nopLogger},
 		Config: &config.ServiceConfig{
-			MessageServerUrl: os.Getenv("SERVER_URL"),
+			MessageServerUrl: serverUrl,
 		},
-	})
+	}
+}
+
+func TestCrawler_Get(t *testing.T) {
+	crawler := NewCrawler(testBotContext(os.Getenv("SERVER_URL")))
 
 	results := crawler.Projects()
 	t.Log(len(results))
@@ -43,11 +51,7 @@ func TestCrawler_Fetch(t *testing.T) {
 	db.Debug()
 	dal.SetDefault(db)
 
-	crawler := NewCrawler(&BotContext{
-		Config: &config.ServiceConfig{
-			MessageServerUrl: config.MessageServerUrl(),
-		},
-	})
+	crawler := NewCrawler(testBotContext(config.MessageServerUrl()))
 
 	userId := int64(1111)
 	result := crawler.Alarms([]string{"中国"}, userId)


### PR DESCRIPTION
Multiple alarms reference the same notice (origin notice id) and the
breakFaith/suspend lists overlap, so without a cache the same detail
endpoint gets hit N+1 times per Process() run.

Also fix crawler tests: BotContext was missing a Logger, causing nil
pointer panics; add a test helper that wires a no-op logger so the
crawler can actually be exercised against SERVER_URL.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>