### PR TITLE
perf: fetch alarm lists for keywords concurrently

### DIFF
--- a/pkg/handler/crawler.go
+++ b/pkg/handler/crawler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/gythialy/magnet/pkg/utils"
@@ -103,17 +104,29 @@ func (c *Crawler) Projects() []*Project {
 }
 
 func (c *Crawler) alarmListByKeywords(keywords []string, alarmType constant.CreditType) []*model.Alarm {
-	var result []*model.Alarm
-	for _, keyword := range keywords {
-		params := map[string]string{
-			"creditName": keyword,
-			"channel":    alarmType.String(),
-			"siteId":     siteId,
-		}
-		if list, err := c.alarmList(params); err == nil {
-			result = append(result, list...)
-		}
+	if len(keywords) == 0 {
+		return nil
 	}
+	result := make([]*model.Alarm, 0, len(keywords)*10)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, keyword := range keywords {
+		wg.Add(1)
+		go func(kw string) {
+			defer wg.Done()
+			params := map[string]string{
+				"creditName": kw,
+				"channel":    alarmType.String(),
+				"siteId":     siteId,
+			}
+			if list, err := c.alarmList(params); err == nil {
+				mu.Lock()
+				result = append(result, list...)
+				mu.Unlock()
+			}
+		}(keyword)
+	}
+	wg.Wait()
 	return result
 }
 


### PR DESCRIPTION
The per-keyword alarm list requests ran serially; with multiple
monitored keywords each Process() run waited through all of them
one by one. Fetch them in parallel goroutines and merge results.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>