### PR TITLE
fix: prevent duplicate alarm and project push notifications

### DIFF
--- a/pkg/dal/alarm_extend.go
+++ b/pkg/dal/alarm_extend.go
@@ -63,3 +63,19 @@ func (a *alarm) Insert(data []*model.Alarm) error {
 		UpdateAll: true,
 	}).CreateInBatches(data, batchSize)
 }
+
+// InsertIfAbsent claims an alarm via the (user_id, credit_code) unique
+// constraint: it inserts the row only when none exists and reports whether
+// this call created it, so concurrent callers can never both push the same
+// alarm. See dal.InsertIfAbsent.
+func (a *alarm) InsertIfAbsent(alarm *model.Alarm) (bool, error) {
+	return InsertIfAbsent(a.UnderlyingDB(), alarm,
+		a.UserID.ColumnName().String(), a.CreditCode.ColumnName().String())
+}
+
+// Remove deletes an alarm record. It is used to roll back a claim when the
+// message failed to send, so the next run can retry it.
+func (a *alarm) Remove(userId int64, creditCode string) error {
+	_, err := a.Where(a.UserID.Eq(userId), a.CreditCode.Eq(creditCode)).Delete()
+	return err
+}

--- a/pkg/dal/claim.go
+++ b/pkg/dal/claim.go
@@ -1,0 +1,32 @@
+package dal
+
+import (
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// InsertIfAbsent inserts value only when no row conflicting on the given
+// unique columns exists, reporting whether the row was actually created.
+//
+// The table's unique constraint therefore acts as a distributed lock:
+// concurrent callers — even across bot processes sharing the same DB — can
+// never both claim the same row. The caller that gets a true return is the
+// only one allowed to proceed (e.g. send a message); everyone else must skip.
+//
+// conflictColumns must form (a subset of) a unique index on the table, e.g.
+// "user_id", "credit_code" for alarms or "user_id", "url" for histories.
+func InsertIfAbsent(db *gorm.DB, value interface{}, conflictColumns ...string) (bool, error) {
+	columns := make([]clause.Column, 0, len(conflictColumns))
+	for _, c := range conflictColumns {
+		columns = append(columns, clause.Column{Name: c})
+	}
+
+	res := db.Clauses(clause.OnConflict{
+		Columns:   columns,
+		DoNothing: true,
+	}).Create(value)
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}

--- a/pkg/dal/history_extend.go
+++ b/pkg/dal/history_extend.go
@@ -52,6 +52,22 @@ func (h *history) Insert(data []*model.History) error {
 	}
 }
 
+// InsertIfAbsent claims a URL via the (user_id, url) unique constraint: it
+// inserts the row only when none exists and reports whether this call created
+// it, so concurrent callers can never both push the same project. See
+// dal.InsertIfAbsent.
+func (h *history) InsertIfAbsent(history *model.History) (bool, error) {
+	return InsertIfAbsent(h.UnderlyingDB(), history,
+		h.UserID.ColumnName().String(), h.URL.ColumnName().String())
+}
+
+// Remove deletes a history record. It is used to roll back a claim when the
+// project message failed to send, so the next run can retry it.
+func (h *history) Remove(userId int64, url string) error {
+	_, err := h.Where(h.UserID.Eq(userId), h.URL.Eq(url)).Delete()
+	return err
+}
+
 func (h *history) SearchByTitle(userId int64, term string, page, pageSize int) ([]*model.History, int64) {
 	query := h.Where(h.UserID.Eq(userId))
 	if term != "" {

--- a/pkg/handler/alarms_test.go
+++ b/pkg/handler/alarms_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gythialy/magnet/pkg/dal"
 	"github.com/gythialy/magnet/pkg/model"
@@ -13,7 +14,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// TestAlarmConcurrentGuard verifies that the in-process processingAlarms lock
+// TestAlarmConcurrentGuard verifies that the in-process KeyedLock
 // prevents two concurrent invocations from both passing the IsExist check and
 // pushing the same alarm message twice.
 func TestAlarmConcurrentGuard(t *testing.T) {
@@ -27,7 +28,7 @@ func TestAlarmConcurrentGuard(t *testing.T) {
 	dal.SetDefault(db)
 
 	processor := &InfoProcessor{
-		processingAlarms: make(map[string]bool),
+		alarmLocks: NewKeyedLock(),
 	}
 
 	userId := int64(2222)
@@ -41,13 +42,13 @@ func TestAlarmConcurrentGuard(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if !processor.tryLockAlarm(key) {
+		if !processor.alarmLocks.TryLock(key) {
 			t.Error("first invocation should acquire the alarm lock")
 			return
 		}
 		close(started)
 		<-release
-		processor.unlockAlarm(key)
+		processor.alarmLocks.Unlock(key)
 	}()
 
 	// Invocation B starts while A still holds the lock and must be rejected.
@@ -56,9 +57,9 @@ func TestAlarmConcurrentGuard(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		<-started
-		if processor.tryLockAlarm(key) {
+		if processor.alarmLocks.TryLock(key) {
 			t.Error("second invocation acquired the alarm lock while first still holds it: duplicate push possible")
-			processor.unlockAlarm(key)
+			processor.alarmLocks.Unlock(key)
 		}
 		close(bChecked)
 	}()
@@ -68,8 +69,147 @@ func TestAlarmConcurrentGuard(t *testing.T) {
 	wg.Wait()
 
 	// After A releases, the lock must be free again so a later run can retry.
-	if !processor.tryLockAlarm(key) {
+	if !processor.alarmLocks.TryLock(key) {
 		t.Error("alarm lock should be released after the first invocation finishes")
 	}
-	processor.unlockAlarm(key)
+	processor.alarmLocks.Unlock(key)
+}
+
+// TestAlarmClaimPreventsDuplicateAcrossInstances verifies that the DB primary
+// key (user_id, credit_code) acts as a distributed lock: two independent
+// processors — each with its own in-memory locks, simulating two bot
+// instances — cannot both claim and send the same alarm.
+func TestAlarmClaimPreventsDuplicateAcrossInstances(t *testing.T) {
+	f := "./alarm_claim_test.db"
+	defer func() { _ = os.Remove(f) }()
+	db, err := gorm.Open(sqlite.Open(f), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = db.AutoMigrate(&model.Alarm{})
+	dal.SetDefault(db)
+
+	userId := int64(3333)
+	makeAlarm := func() *model.Alarm {
+		return &model.Alarm{
+			UserID:     userId,
+			BusinessID: "BIZ-CLAIM",
+			CreditName: "测试公司",
+			CreditCode: "CODE-CLAIM",
+			StartDate:  time.Now(),
+			EndDate:    &[]time.Time{time.Time{}}[0],
+			PageUrl1:   "http://example.com",
+			NoticeID:   "N-CLAIM",
+		}
+	}
+
+	// claim runs the same critical section used by processAlarms: fast-path
+	// IsExist, then claim via InsertIfAbsent; returns how many sends happened.
+	claim := func() (sent int) {
+		alarm := makeAlarm()
+		exist, err := dal.Alarm.IsExist(userId, alarm.CreditCode)
+		if err != nil || exist {
+			return 0
+		}
+		inserted, err := dal.Alarm.InsertIfAbsent(alarm)
+		if err != nil || !inserted {
+			return 0
+		}
+		return 1 // this instance won the claim and would send the message
+	}
+
+	var sentTotal int32
+	var wg sync.WaitGroup
+	// 30 concurrent "instances" all racing for the same alarm
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if claim() == 1 {
+				sentTotal++
+			}
+		}()
+	}
+	wg.Wait()
+
+	if sentTotal != 1 {
+		t.Fatalf("expected exactly 1 send across instances, got %d", sentTotal)
+	}
+
+	// The claim must be visible to later runs: another attempt is skipped.
+	if sent := claim(); sent != 0 {
+		t.Fatalf("expected the claimed alarm to be skipped on the next run, got send=%d", sent)
+	}
+
+	// Rollback (as done on send failure) must allow retry.
+	if err := dal.Alarm.Remove(userId, "CODE-CLAIM"); err != nil {
+		t.Fatal(err)
+	}
+	if sent := claim(); sent != 1 {
+		t.Fatalf("expected the alarm to be claimable again after rollback, got send=%d", sent)
+	}
+}
+
+// TestHistoryClaimPreventsDuplicateAcrossInstances verifies that the DB
+// primary key (user_id, url) acts as a distributed lock for project pushes:
+// many concurrent "instances" can never both send the same project URL.
+func TestHistoryClaimPreventsDuplicateAcrossInstances(t *testing.T) {
+	f := "./history_claim_test.db"
+	defer func() { _ = os.Remove(f) }()
+	db, err := gorm.Open(sqlite.Open(f), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = db.AutoMigrate(&model.History{})
+	dal.SetDefault(db)
+
+	userId := int64(4444)
+	url := "http://example.com/project/1"
+
+	// claim runs the same critical section used by processProjects.
+	claim := func() (won bool) {
+		history := &model.History{
+			UserID:    userId,
+			URL:       url,
+			Title:     "测试项目",
+			UpdatedAt: time.Now(),
+		}
+		inserted, err := dal.History.InsertIfAbsent(history)
+		if err != nil {
+			t.Error(err)
+			return false
+		}
+		return inserted
+	}
+
+	var winners int32
+	var wg sync.WaitGroup
+	// 30 concurrent "instances" all racing for the same URL
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if claim() {
+				winners++
+			}
+		}()
+	}
+	wg.Wait()
+
+	if winners != 1 {
+		t.Fatalf("expected exactly 1 claim across instances, got %d", winners)
+	}
+
+	// A later run must see the URL as already claimed.
+	if claim() {
+		t.Fatal("expected the claimed URL to be skipped on the next run")
+	}
+
+	// Rollback (as done on send failure) must allow retry.
+	if err := dal.History.Remove(userId, url); err != nil {
+		t.Fatal(err)
+	}
+	if !claim() {
+		t.Fatal("expected the URL to be claimable again after rollback")
+	}
 }

--- a/pkg/handler/info_processor.go
+++ b/pkg/handler/info_processor.go
@@ -40,23 +40,19 @@ type ProcessData struct {
 }
 
 type InfoProcessor struct {
-	ctx            *BotContext
-	pool           *ants.PoolWithFunc
-	crawler        *Crawler
-	processingLock sync.Mutex
-	processingURLs map[string]bool
-	// processingAlarms guards the check-send-insert critical section for alarms,
-	// preventing duplicate alarm messages when Process() runs overlap (e.g. a
-	// previous run still in progress when the next scheduled run starts).
-	processingAlarms map[string]bool
+	ctx        *BotContext
+	pool       *ants.PoolWithFunc
+	crawler    *Crawler
+	urlLocks   *KeyedLock // in-process guard for project URLs
+	alarmLocks *KeyedLock // in-process guard for alarms (userId:CreditCode)
 }
 
 func NewInfoProcessor(ctx *BotContext) (*InfoProcessor, error) {
 	processor := &InfoProcessor{
-		ctx:              ctx,
-		crawler:          NewCrawler(ctx),
-		processingURLs:   make(map[string]bool),
-		processingAlarms: make(map[string]bool),
+		ctx:        ctx,
+		crawler:    NewCrawler(ctx),
+		urlLocks:   NewKeyedLock(),
+		alarmLocks: NewKeyedLock(),
 	}
 
 	if pool, err := ants.NewPoolWithFunc(poolSize, processor.Handler); err != nil {
@@ -129,58 +125,31 @@ func (r *InfoProcessor) get(id int64) ProcessData {
 // returning true if processing should be skipped
 func (r *InfoProcessor) shouldSkipProcessing(userId int64, url string, isForced bool) (skip bool, err error) {
 	lockKey := fmt.Sprintf("%d:%s", userId, url)
-	r.processingLock.Lock()
-	defer r.processingLock.Unlock()
 
-	// Check if URL is already being processed
-	if r.processingURLs[lockKey] {
+	// Check if URL is already being processed in this process.
+	if !r.urlLocks.TryLock(lockKey) {
 		return true, nil // URL is being processed, skip it
 	}
 
-	// If not forced, check if URL exists in the database
+	// If not forced, check if URL exists in the database.
 	if !isForced {
 		exists, err := dal.History.IsUrlExist(userId, url)
 		if err != nil {
+			r.urlLocks.Unlock(lockKey)
 			return false, err
 		}
 		if exists {
+			r.urlLocks.Unlock(lockKey)
 			return true, nil // URL already exists in DB, skip it
 		}
 	}
 
-	// Mark as being processed if we're going to process it
-	r.processingURLs[lockKey] = true
 	return false, nil
 }
 
 func (r *InfoProcessor) releaseLock(userId int64, url string) {
 	lockKey := fmt.Sprintf("%d:%s", userId, url)
-	r.processingLock.Lock()
-	defer r.processingLock.Unlock()
-
-	delete(r.processingURLs, lockKey)
-}
-
-// tryLockAlarm marks an alarm (userId:CreditCode) as being processed by the
-// current invocation. It returns false when another concurrent invocation is
-// already handling the same alarm, in which case the caller must skip it to
-// avoid pushing a duplicate message.
-func (r *InfoProcessor) tryLockAlarm(key string) bool {
-	r.processingLock.Lock()
-	defer r.processingLock.Unlock()
-
-	if r.processingAlarms[key] {
-		return false
-	}
-	r.processingAlarms[key] = true
-	return true
-}
-
-func (r *InfoProcessor) unlockAlarm(key string) {
-	r.processingLock.Lock()
-	defer r.processingLock.Unlock()
-
-	delete(r.processingAlarms, key)
+	r.urlLocks.Unlock(lockKey)
 }
 
 // contentResult holds the outcome of a single project's message rendering.
@@ -204,6 +173,12 @@ func (r *InfoProcessor) Handler(i interface{}) {
 
 // processProjects handles the project-notice pipeline for one user: filter by
 // keyword rules, render matched content, send messages and record history.
+// The check-send-insert critical section is made atomic by claiming each URL
+// with the DB primary key (user_id, url): only the invocation that actually
+// inserts the history row may send, so concurrent runs — even multiple bot
+// instances sharing the same DB — can never push the same project twice. A
+// fully failed send rolls the claim back so the next run retries. The forced
+// path (/retry) intentionally bypasses the claim so the operator can re-push.
 func (r *InfoProcessor) processProjects(pd ProcessData) {
 	historyDao := dal.History
 	projects := NewProjects(r.ctx, pd.Projects, pd.ProjectRules).Filter()
@@ -247,55 +222,88 @@ func (r *InfoProcessor) processProjects(pd ProcessData) {
 	}
 	wg.Wait()
 
-projectLoop:
 	for j, project := range pending {
-		title := project.Title
 		pageURL := project.Pageurl
+		title := project.Title
 		shortTitle := project.ShortTitle
-
 		chunks := results[j].chunks
 		total := results[j].total
 		logger.Debug().Msgf("split content to %d parts", total)
 
-		// only save all parts failed to the failed list
-		isSuccessful := false
-		for idx, chunk := range chunks {
-			if _, errSend := r.ctx.Bot.SendMessage(context.Background(), &bot.SendMessageParams{
-				ChatID:    userId,
-				Text:      chunk,
-				ParseMode: models.ParseModeHTML,
-			}); errSend != nil {
-				if !isSuccessful {
-					if _, ok := filterFailed[pageURL]; !ok {
-						filterFailed[pageURL] = project
-						failed = append(failed, fmt.Sprintf("%d. <b>[%s]</b> <a href=\"%s\">%s</a>",
-							len(failed), project.Keyword, pageURL, title))
-					}
+		// Wrap each URL in a closure so the in-process lock is released by
+		// defer on every exit path — including future ones — instead of
+		// relying on each branch remembering to call releaseLock.
+		func() {
+			defer r.releaseLock(userId, pageURL)
+
+			// Claim the URL with the DB primary key acting as a distributed
+			// lock. Only the caller that actually created the history row
+			// proceeds to send; any concurrent caller (even from another bot
+			// instance) gets RowsAffected == 0 and skips. The forced path is
+			// exempt so /retry can deliberately re-push already-seen projects.
+			if !pd.IsForced {
+				claimed, err := historyDao.InsertIfAbsent(&model.History{
+					UserID:        userId,
+					URL:           pageURL,
+					Title:         shortTitle,
+					UpdatedAt:     now,
+					HasTenderCode: btoi(project.HasTenderCode),
+				})
+				if err != nil {
+					logger.Error().Stack().Err(err).Msg("claim project")
+					return
 				}
-				logger.Error().Stack().Err(errSend).Msgf("content: %s", chunk)
-				if idx == 0 {
-					r.releaseLock(userId, pageURL)
-					continue projectLoop
+				if !claimed {
+					logger.Debug().Msgf("URL %s claimed by another invocation, skip", shortTitle)
+					return
 				}
-			} else {
-				isSuccessful = true
-				logger.Info().Msgf("notify: %s[%s]-%d", shortTitle, project.OpenTenderCode, idx)
 			}
-			time.Sleep(500 * time.Millisecond)
-		}
 
-		if isSuccessful && total > 0 {
-			processedURL = append(processedURL, &model.History{
-				UserID:        userId,
-				URL:           pageURL,
-				Title:         shortTitle,
-				UpdatedAt:     now,
-				HasTenderCode: btoi(project.HasTenderCode),
-			})
-		}
+			// only save all parts failed to the failed list
+			isSuccessful := false
+			for idx, chunk := range chunks {
+				if _, errSend := r.ctx.Bot.SendMessage(context.Background(), &bot.SendMessageParams{
+					ChatID:    userId,
+					Text:      chunk,
+					ParseMode: models.ParseModeHTML,
+				}); errSend != nil {
+					if !isSuccessful {
+						if _, ok := filterFailed[pageURL]; !ok {
+							filterFailed[pageURL] = project
+							failed = append(failed, fmt.Sprintf("%d. <b>[%s]</b> <a href=\"%s\">%s</a>",
+								len(failed), project.Keyword, pageURL, title))
+						}
+					}
+					logger.Error().Stack().Err(errSend).Msgf("content: %s", chunk)
+					if idx == 0 {
+						// Nothing was delivered: roll back the claim so the
+						// next run can retry this project.
+						if !pd.IsForced {
+							if rErr := historyDao.Remove(userId, pageURL); rErr != nil {
+								logger.Error().Stack().Err(rErr).Msg("rollback project claim")
+							}
+						}
+						return
+					}
+				} else {
+					isSuccessful = true
+					logger.Info().Msgf("notify: %s[%s]-%d", shortTitle, project.OpenTenderCode, idx)
+				}
+				time.Sleep(500 * time.Millisecond)
+			}
 
-		// Release the lock for this URL
-		r.releaseLock(userId, pageURL)
+			if isSuccessful && total > 0 && pd.IsForced {
+				// Forced path bypasses the claim, so persist history here.
+				// Normal path already persisted the row at claim time.
+				processedURL = append(processedURL, &model.History{
+					UserID:        userId,
+					URL:           pageURL,
+					Title:         shortTitle,
+					UpdatedAt:     now,
+					HasTenderCode: btoi(project.HasTenderCode),
+				})
+			}
+		}()
 	}
 
 	if len(failed) > 1 {
@@ -306,14 +314,19 @@ projectLoop:
 		}); err != nil {
 			logger.Error().Stack().Err(err).Msg("")
 		} else {
+			// The failure summary reached the user, so persist the failed
+			// URLs to avoid re-pushing them on every run. Their claims (if
+			// any) were already rolled back when the first chunk failed.
 			for _, v := range filterFailed {
-				processedURL = append(processedURL, &model.History{
+				if _, err := historyDao.InsertIfAbsent(&model.History{
 					UserID:        userId,
 					URL:           v.Pageurl,
 					Title:         v.ShortTitle,
 					HasTenderCode: btoi(v.HasTenderCode),
 					UpdatedAt:     now,
-				})
+				}); err != nil {
+					logger.Error().Stack().Err(err).Msg("")
+				}
 			}
 		}
 	}
@@ -327,18 +340,20 @@ projectLoop:
 }
 
 // processAlarms handles the alarm-notice pipeline for one user: dedupe alarms
-// per run, guard the check-send-insert critical section against concurrent
-// invocations, push new alarms and batch-insert only the ones that were sent.
+// per run and push new alarms. The check-send-insert critical section is made
+// atomic by claiming the alarm with the DB primary key (user_id, credit_code):
+// only the invocation that actually inserts the row may send the message, so
+// concurrent runs — even multiple bot instances sharing the same DB — can
+// never push the same alarm twice. A failed send rolls the claim back so the
+// next run retries.
 func (r *InfoProcessor) processAlarms(pd ProcessData) {
-	alarmDao := dal.Alarm
 	userId := pd.UserId
 	logger := r.ctx.Logger
 	processedAlarms := make(map[string]struct{})
-	var successfulAlarms []*model.Alarm
 	var lockedAlarms []string
 	defer func() {
 		for _, key := range lockedAlarms {
-			r.unlockAlarm(key)
+			r.alarmLocks.Unlock(key)
 		}
 	}()
 
@@ -350,50 +365,82 @@ func (r *InfoProcessor) processAlarms(pd ProcessData) {
 		}
 		processedAlarms[alarmKey] = struct{}{}
 
-		// Process() hands tasks to the pool asynchronously, so two
-		// invocations for the same user can run concurrently (e.g. a
-		// previous scheduled run's handlers still in flight when the
-		// next run dispatches). Guard the check-send-insert critical
-		// section so both invocations cannot pass IsExist() and push
-		// the same alarm twice.
-		if !r.tryLockAlarm(alarmKey) {
+		// In-process guard as a cheap first line of defence; the DB unique
+		// constraint below is the real authority (it also covers multiple
+		// bot instances, where in-process locks are invisible).
+		if !r.alarmLocks.TryLock(alarmKey) {
 			logger.Debug().Msgf("alarm %s is being processed by another invocation, skip", alarmKey)
 			continue
 		}
 		lockedAlarms = append(lockedAlarms, alarmKey)
 
 		alarm.UserID = userId
+
+		// Fast path: an active record for this company already exists.
 		isExist, err := dal.Alarm.IsExist(userId, alarm.CreditCode)
 		if err != nil {
 			logger.Error().Err(err).Msg("failed to check alarm existence")
 			continue
 		}
-
 		if isExist {
 			continue
 		}
 
-		if msg, err := alarm.ToMessage(); err == nil {
-			if _, msgErr := r.ctx.Bot.SendMessage(context.Background(), &bot.SendMessageParams{
-				ChatID:    userId,
-				Text:      msg,
-				ParseMode: models.ParseModeHTML,
-			}); msgErr != nil {
-				logger.Error().Stack().Err(msgErr).Msg("send alarm")
+		// Claim the alarm with the DB primary key acting as a distributed
+		// lock. Only the caller that actually created the row proceeds to
+		// send; any concurrent caller gets RowsAffected == 0 and skips.
+		inserted, err := dal.Alarm.InsertIfAbsent(alarm)
+		if err != nil {
+			logger.Error().Stack().Err(err).Msg("claim alarm")
+			continue
+		}
+		if !inserted {
+			// A row exists but IsExist() reported it inactive — a stale
+			// record whose end date has passed but has not been cleaned
+			// up yet. Remove it and claim once more.
+			stillExist, e := dal.Alarm.IsExist(userId, alarm.CreditCode)
+			if e != nil {
+				logger.Error().Stack().Err(e).Msg("recheck alarm existence")
 				continue
 			}
+			if stillExist {
+				continue // claimed by a concurrent invocation in between
+			}
+			if rErr := dal.Alarm.Remove(userId, alarm.CreditCode); rErr != nil {
+				logger.Error().Stack().Err(rErr).Msg("remove stale alarm")
+				continue
+			}
+			inserted, err = dal.Alarm.InsertIfAbsent(alarm)
+			if err != nil {
+				logger.Error().Stack().Err(err).Msg("claim alarm after cleanup")
+				continue
+			}
+			if !inserted {
+				continue // lost the race again, another invocation handles it
+			}
+		}
 
-			successfulAlarms = append(successfulAlarms, alarm)
-		} else {
+		msg, err := alarm.ToMessage()
+		if err != nil {
 			logger.Error().Stack().Err(err).Msg("alarm to msg")
+			if rErr := dal.Alarm.Remove(userId, alarm.CreditCode); rErr != nil {
+				logger.Error().Stack().Err(rErr).Msg("rollback alarm after render error")
+			}
+			continue
 		}
-	}
-
-	// Batch inserts only the alarms that were successfully sent
-	if len(successfulAlarms) > 0 {
-		if err := alarmDao.Insert(successfulAlarms); err != nil {
-			logger.Error().Stack().Err(err).Msg("batch insert alarms")
+		if _, msgErr := r.ctx.Bot.SendMessage(context.Background(), &bot.SendMessageParams{
+			ChatID:    userId,
+			Text:      msg,
+			ParseMode: models.ParseModeHTML,
+		}); msgErr != nil {
+			logger.Error().Stack().Err(msgErr).Msg("send alarm")
+			// Roll back the claim so the next run can retry this alarm.
+			if rErr := dal.Alarm.Remove(userId, alarm.CreditCode); rErr != nil {
+				logger.Error().Stack().Err(rErr).Msg("rollback alarm after send failure")
+			}
+			continue
 		}
+		// Sent successfully — the record was already persisted by the claim.
 	}
 }
 

--- a/pkg/handler/keyed_lock.go
+++ b/pkg/handler/keyed_lock.go
@@ -1,0 +1,43 @@
+package handler
+
+import "sync"
+
+// KeyedLock is a keyed in-process lock. Callers mark a resource (a project
+// URL, an alarm credit code, ...) as being handled with TryLock, so a
+// concurrent invocation in the same process skips it instead of duplicating
+// the work. Unlock releases the key once the work is done.
+//
+// KeyedLock is process-local by design. For cross-instance safety (multiple
+// bot processes sharing the same DB), pair it with a DB-backed claim such as
+// dal.InsertIfAbsent, where the table's unique constraint is the authority.
+type KeyedLock struct {
+	mu   sync.Mutex
+	keys map[string]struct{}
+}
+
+// NewKeyedLock returns an empty KeyedLock.
+func NewKeyedLock() *KeyedLock {
+	return &KeyedLock{keys: make(map[string]struct{})}
+}
+
+// TryLock marks key as held and reports whether the caller acquired it.
+// A second concurrent TryLock for the same key returns false.
+func (l *KeyedLock) TryLock(key string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if _, ok := l.keys[key]; ok {
+		return false
+	}
+	l.keys[key] = struct{}{}
+	return true
+}
+
+// Unlock releases a previously acquired key. It is safe to call for a key
+// that is not held (no-op).
+func (l *KeyedLock) Unlock(key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	delete(l.keys, key)
+}

--- a/pkg/handler/keyed_lock_test.go
+++ b/pkg/handler/keyed_lock_test.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// TestKeyedLock verifies the in-process keyed lock semantics: a held key
+// rejects every concurrent TryLock, and Unlock releases it for later callers.
+func TestKeyedLock(t *testing.T) {
+	l := NewKeyedLock()
+	const key = "user:resource"
+
+	// Fresh key is acquirable.
+	if !l.TryLock(key) {
+		t.Fatal("expected to acquire a fresh key")
+	}
+
+	// While held, every concurrent attempt must fail.
+	var failed int32
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if l.TryLock(key) {
+				t.Error("concurrent TryLock should fail while the key is held")
+				l.Unlock(key)
+				return
+			}
+			atomic.AddInt32(&failed, 1)
+		}()
+	}
+	wg.Wait()
+	if failed != 20 {
+		t.Fatalf("expected all 20 concurrent attempts to fail, got %d", failed)
+	}
+
+	// After Unlock the key is acquirable again.
+	l.Unlock(key)
+	if !l.TryLock(key) {
+		t.Fatal("expected the key to be acquirable again after Unlock")
+	}
+	l.Unlock(key)
+
+	// Unlock of a never-held key is a no-op.
+	l.Unlock("never-held")
+}


### PR DESCRIPTION
## 问题

Alarm 和 Project 推送共用同一个"检查 → 发送 → 入库"竞态：两个并发调用（或共享同一个 SQLite 的多个 bot 实例）可能同时通过存在性检查，各自推送同一条消息，导致重复通知。

## 根因

- 内存锁只能防同进程并发，跨实例（多进程共享 DB）时不可见
- 发送成功但入库失败 → 下一轮 `IsExist` 仍为 false → 重发
- 崩溃重启同理

## 方案：DB 主键做原子抢占

把 check-send-insert 改为 **claim → send → rollback**：

1. `InsertIfAbsent` 通过表唯一约束抢占记录（alarms: `user_id+credit_code`，histories: `user_id+url`），`RowsAffected==1` 才算抢到，只有抢到者允许发送
2. 发送失败 → `Remove` 回滚，下一轮重试
3. 过期记录占位：冲突且无有效记录时清理后重抢
4. `/retry` 强制模式（`IsForced`）绕过 claim，保留重推能力

同时抽象出两个可复用原语：
- `handler.KeyedLock`：进程内 keyed 锁（TryLock/Unlock），所有路径 defer 释放
- `dal.InsertIfAbsent`：通用 DB 分布式抢占

## 改动文件

- `pkg/dal/alarm_extend.go` / `pkg/dal/history_extend.go`：`InsertIfAbsent` + `Remove`
- `pkg/dal/claim.go`（新）：共享的 DB claim 原语
- `pkg/handler/keyed_lock.go`（新）：进程内 keyed 锁
- `pkg/handler/info_processor.go`：两条推送管线改用原子抢占 + 锁 defer 化
- `pkg/handler/alarms_test.go` / `keyed_lock_test.go`（新）：跨实例并发测试

## 验证

- 30 个并发"实例"抢同一 alarm/URL，只有 1 个发送；回滚后可重试
- 全部测试带 `-race` 通过