### PR TITLE
refactor: simplify push pipelines onto a shared PushPipeline skeleton

### DIFF
--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -1,0 +1,158 @@
+# magnet-bot 推送管线重构方案
+
+> 状态：方案 v1（2026-08-04），**Step 1-3 已在 PR #362 落地，Step 4-5 待评估**
+> 背景：PR #361 落地了"DB 原子抢占 + KeyedLock"修复后，alarm/project 两条推送管线仍有大量重复与状态交织，本方案目标是简化实现、消除重复，且不改变外部行为。
+
+---
+
+## 一、现状痛点
+
+### 1. 两条管线的 claim → send → rollback 逻辑重复（核心）
+
+`processProjects` 与 `processAlarms` 各自手写了一遍相同的模式：
+
+```
+内存锁 TryLock → DB 抢占(InsertIfAbsent) → 发送 → 失败回滚(Remove)
+```
+
+差异只在：唯一键的组成、发送内容、失败语义。目前是复制粘贴两份，后续加第三条管线（如新增通知类型）会再复制一份。
+
+### 2. `processProjects` 单个函数状态交织（复杂度的主来源）
+
+一个函数里同时管理：
+
+- `pending` 预筛选 + 并发渲染
+- 多 chunk 发送循环（`isSuccessful` 部分成功语义）
+- `failed` / `filterFailed` 失败汇总（最后补发一条汇总消息）
+- `processedURL` 强制模式落库
+- claim 回滚 + 内存锁释放（已用闭包 + defer 加固，但闭包加深了嵌套）
+
+函数 160+ 行，读起来要在 6 个状态变量之间跳转。
+
+### 3. `processAlarms` 过期占位重抢逻辑嵌套深
+
+`!inserted` 分支里：再查 IsExist → Remove 旧记录 → 重抢 → 可能再失败，4 层嵌套，且与"并发抢先"分支的区分靠注释。
+
+### 4. 双重检查冗余
+
+`shouldSkipProcessing`（内存锁 + IsUrlExist）之后马上又做 `InsertIfAbsent` claim。内存锁和 DB claim 各查一遍，语义有重叠（内存锁其实已被 DB 唯一约束完全覆盖，仅剩"省一次渲染"的优化价值）。
+
+### 5. `ProcessData` 把两类数据捆在一起串行处理
+
+`Handler` 对同一用户先跑 projects 再跑 alarms，两个 pipeline 互相拖慢（项目多时告警延迟）。
+
+---
+
+## 二、目标架构
+
+```
+                    ┌────────────────────────────┐
+                    │   PushPipeline (泛型原语)   │
+                    │  - KeyedLock 内存锁         │
+                    │  - InsertIfAbsent 抢占      │
+                    │  - send / rollback 回调     │
+                    └────────────────────────────┘
+                          ▲            ▲
+        processProjects   │            │  processAlarms
+        （实现多chunk/汇总） │            │  （实现单条发送）
+                          │            │
+                  ┌───────┴────┐  ┌───┴────────┐
+                  │ HistoryDAO │  │ AlarmDAO   │
+                  └────────────┘  └────────────┘
+```
+
+- **统一原语**：`PushPipeline` 泛型处理"锁 → 抢占 → 发送 → 回滚"骨架，管线只需提供 4 个回调。
+- **行为不变**：projects 的多 chunk / 失败汇总 / IsForced 强制模式、alarms 的过期占位重抢，全部保留在各自管线内部。
+
+---
+
+## 三、分步实施计划（每步可独立成 PR）
+
+✅ ### Step 1：提取通用 `PushPipeline` 泛型原语（核心步骤）
+
+新增 `pkg/handler/push_pipeline.go`：
+
+```go
+// ClaimHandle 定义一条可抢占推送的最小单元。
+type ClaimHandle struct {
+    Key      string        // 唯一键，如 "userId:creditCode"
+    Claim    func() (bool, error) // DB 抢占，返回是否抢到
+    Rollback func() error  // 发送失败回滚
+    Send     func() error  // 真正发送
+}
+
+// PushPipeline 串行处理一批 handle：内存锁 → claim → send → 失败回滚。
+type PushPipeline struct {
+    locks *KeyedLock
+    log   *utils.Logger
+}
+
+func (p *PushPipeline) Run(handles []ClaimHandle) {
+    for _, h := range handles {
+        func() {
+            if !p.locks.TryLock(h.Key) { return }
+            defer p.locks.Unlock(h.Key)
+
+            claimed, err := h.Claim()
+            if err != nil || !claimed { return }
+
+            if err := h.Send(); err != nil {
+                _ = h.Rollback()
+            }
+        }()
+    }
+}
+```
+
+改造后：
+
+- `processAlarms` 变成"构建 []ClaimHandle → 跑 Run"，删除全部手写锁/回滚样板，`!inserted` 的过期重抢收进一个 `claimOrRefresh` 回调。
+- `processProjects` 的主循环同样改为构建 handles，把多 chunk 发送 + 汇总逻辑留在 `Send` 回调里（单 URL 处理抽成方法，闭包+大函数消失）。
+
+**验收**：现有 `-race` 测试全过；`TestAlarmClaimPreventsDuplicateAcrossInstances` / `TestHistoryClaimPreventsDuplicateAcrossInstances` 语义不变。
+
+✅ ### Step 2：`processProjects` 瘦身
+
+- 单 URL 处理抽成 `r.pushProject(userId, project, results[j], isForced) (success bool)` 方法，主循环只剩"收集 handles / 跑管线"几行。
+- `failed` / `filterFailed` / `processedURL` 从函数级状态收进小结构体或局部闭包。
+- 目标：`processProjects` 从 160+ 行降到 ~40 行骨架。
+
+**验收**：行为等价（对比重构前后日志输出 `notify:` / failed 汇总）。
+
+✅ ### Step 3：`processAlarms` 瘦身
+
+- 过期占位重抢封装为 `claimOrRefresh(alarm) (bool, error)`（Remove 旧记录 + 重抢一次，失败回 false）。
+- 主循环只保留"去重 → 构建 handle → Run"。
+
+**验收**：跨实例并发测试 + 过期记录单元测试。
+
+### Step 4：消除双重检查（可选，收益评估后决定）
+
+- 保留 `shouldSkipProcessing` 作为渲染前的快速过滤（省 CPU），但明确注释其与 claim 的分工：**预筛 vs 权威**。
+- 或：删掉内存锁只留 DB claim（渲染浪费可接受时）。**倾向保留**——预筛能避免大量白渲染。
+
+### Step 5：Pipeline 并行化（独立 PR，性能向）
+
+- `Handler` 里 projects 与 alarms 改为并发执行（两个 goroutine + WaitGroup），互不拖慢。
+- 注意：两者共用同一 SQLite，写并发本身有锁；收益需实测。此步不做也无损正确性。
+
+---
+
+## 四、风险与验证
+
+| 风险 | 缓解 |
+|---|---|
+| 泛型 Pipeline 过度抽象导致难读 | ClaimHandle 保持纯数据 + 回调，不引入框架感；单测覆盖 |
+| 行为漂移（汇总/强制模式/部分成功） | 每步后跑全量测试 + `-race`；Step 2/3 对比重构前后日志 |
+| 并行化后 SQLite 写竞争 | Step 5 独立评估，可回退 |
+
+**测试基线**：`go test ./pkg/handler/ ./pkg/dal/ -race`（`TestMergeLines`、`Test_alarmQuery`、`Test_historyQuery` 为既有失败，与本次无关）。
+
+---
+
+## 五、不做的事（明确边界）
+
+- 不改推送消息内容/格式
+- 不改 `Crawler.Alarms()` 的抓取与去重（按 CreditCode）
+- 不改调度方式（gocron SingletonMode）
+- 不引入消息队列/任务框架——当前规模用不上

--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -1,6 +1,6 @@
 # magnet-bot 推送管线重构方案
 
-> 状态：方案 v1（2026-08-04），**Step 1-3 已在 PR #362 落地，Step 4-5 待评估**
+> 状态：方案 v1（2026-08-04），**全部步骤已在 PR #362 落地**
 > 背景：PR #361 落地了"DB 原子抢占 + KeyedLock"修复后，alarm/project 两条推送管线仍有大量重复与状态交织，本方案目标是简化实现、消除重复，且不改变外部行为。
 
 ---
@@ -126,12 +126,12 @@ func (p *PushPipeline) Run(handles []ClaimHandle) {
 
 **验收**：跨实例并发测试 + 过期记录单元测试。
 
-### Step 4：消除双重检查（可选，收益评估后决定）
+✅ ### Step 4：消除双重检查（保留预筛，明确分工）
 
 - 保留 `shouldSkipProcessing` 作为渲染前的快速过滤（省 CPU），但明确注释其与 claim 的分工：**预筛 vs 权威**。
 - 或：删掉内存锁只留 DB claim（渲染浪费可接受时）。**倾向保留**——预筛能避免大量白渲染。
 
-### Step 5：Pipeline 并行化（独立 PR，性能向）
+✅ ### Step 5：Pipeline 并行化
 
 - `Handler` 里 projects 与 alarms 改为并发执行（两个 goroutine + WaitGroup），互不拖慢。
 - 注意：两者共用同一 SQLite，写并发本身有锁；收益需实测。此步不做也无损正确性。

--- a/pkg/handler/alarms_test.go
+++ b/pkg/handler/alarms_test.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -13,67 +12,6 @@ import (
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 )
-
-// TestAlarmConcurrentGuard verifies that the in-process KeyedLock
-// prevents two concurrent invocations from both passing the IsExist check and
-// pushing the same alarm message twice.
-func TestAlarmConcurrentGuard(t *testing.T) {
-	f := "./alarm_guard_test.db"
-	defer func() { _ = os.Remove(f) }()
-	db, err := gorm.Open(sqlite.Open(f), &gorm.Config{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	_ = db.AutoMigrate(&model.Alarm{})
-	dal.SetDefault(db)
-
-	processor := &InfoProcessor{
-		alarmLocks: NewKeyedLock(),
-	}
-
-	userId := int64(2222)
-	key := fmt.Sprintf("%d:%s", userId, "CODE-X")
-
-	// Invocation A acquires the lock first and holds it while "sending".
-	started := make(chan struct{})
-	release := make(chan struct{})
-	var wg sync.WaitGroup
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if !processor.alarmLocks.TryLock(key) {
-			t.Error("first invocation should acquire the alarm lock")
-			return
-		}
-		close(started)
-		<-release
-		processor.alarmLocks.Unlock(key)
-	}()
-
-	// Invocation B starts while A still holds the lock and must be rejected.
-	bChecked := make(chan struct{})
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		<-started
-		if processor.alarmLocks.TryLock(key) {
-			t.Error("second invocation acquired the alarm lock while first still holds it: duplicate push possible")
-			processor.alarmLocks.Unlock(key)
-		}
-		close(bChecked)
-	}()
-
-	<-bChecked     // wait until B has attempted the lock (A is guaranteed to hold it)
-	close(release) // now let A finish and release the lock
-	wg.Wait()
-
-	// After A releases, the lock must be free again so a later run can retry.
-	if !processor.alarmLocks.TryLock(key) {
-		t.Error("alarm lock should be released after the first invocation finishes")
-	}
-	processor.alarmLocks.Unlock(key)
-}
 
 // TestAlarmClaimPreventsDuplicateAcrossInstances verifies that the DB primary
 // key (user_id, credit_code) acts as a distributed lock: two independent

--- a/pkg/handler/info_processor.go
+++ b/pkg/handler/info_processor.go
@@ -44,7 +44,6 @@ type InfoProcessor struct {
 	pool         *ants.PoolWithFunc
 	crawler      *Crawler
 	urlLocks     *KeyedLock // in-process guard for project URLs
-	alarmLocks   *KeyedLock // in-process guard for alarms (userId:CreditCode)
 	pushPipeline *PushPipeline
 }
 
@@ -53,7 +52,6 @@ func NewInfoProcessor(ctx *BotContext) (*InfoProcessor, error) {
 		ctx:          ctx,
 		crawler:      NewCrawler(ctx),
 		urlLocks:     NewKeyedLock(),
-		alarmLocks:   NewKeyedLock(),
 		pushPipeline: NewPushPipeline(),
 	}
 
@@ -355,108 +353,103 @@ func (r *InfoProcessor) sendProject(st *projectPushState, project *Project, chun
 }
 
 // processAlarms handles the alarm-notice pipeline for one user: dedupe alarms
-// per run and push new alarms. The check-send-insert critical section is made
-// atomic by claiming the alarm with the DB primary key (user_id, credit_code):
-// only the invocation that actually inserts the row may send the message, so
-// concurrent runs — even multiple bot instances sharing the same DB — can
-// never push the same alarm twice. A failed send rolls the claim back so the
-// next run retries.
+// per run, then push each new alarm through the PushPipeline skeleton. The DB
+// primary key (user_id, credit_code) acts as a distributed lock: only the
+// invocation that actually inserts the row may send, so concurrent runs —
+// even multiple bot instances sharing the same DB — can never push the same
+// alarm twice. A failed send rolls the claim back so the next run retries.
 func (r *InfoProcessor) processAlarms(pd ProcessData) {
 	userId := pd.UserId
-	logger := r.ctx.Logger
 	processedAlarms := make(map[string]struct{})
-	var lockedAlarms []string
-	defer func() {
-		for _, key := range lockedAlarms {
-			r.alarmLocks.Unlock(key)
-		}
-	}()
 
+	handles := make([]ClaimHandle, 0, len(pd.Alarms))
 	for _, alarm := range pd.Alarms {
 		alarmKey := fmt.Sprintf("%d:%s", userId, alarm.CreditCode)
 
+		// Crawler already dedupes by credit code; keep the per-run map as a
+		// cheap second line of defence.
 		if _, exists := processedAlarms[alarmKey]; exists {
 			continue
 		}
 		processedAlarms[alarmKey] = struct{}{}
-
-		// In-process guard as a cheap first line of defence; the DB unique
-		// constraint below is the real authority (it also covers multiple
-		// bot instances, where in-process locks are invisible).
-		if !r.alarmLocks.TryLock(alarmKey) {
-			logger.Debug().Msgf("alarm %s is being processed by another invocation, skip", alarmKey)
-			continue
-		}
-		lockedAlarms = append(lockedAlarms, alarmKey)
-
 		alarm.UserID = userId
 
-		// Fast path: an active record for this company already exists.
-		isExist, err := dal.Alarm.IsExist(userId, alarm.CreditCode)
-		if err != nil {
-			logger.Error().Err(err).Msg("failed to check alarm existence")
-			continue
-		}
-		if isExist {
-			continue
-		}
-
-		// Claim the alarm with the DB primary key acting as a distributed
-		// lock. Only the caller that actually created the row proceeds to
-		// send; any concurrent caller gets RowsAffected == 0 and skips.
-		inserted, err := dal.Alarm.InsertIfAbsent(alarm)
-		if err != nil {
-			logger.Error().Stack().Err(err).Msg("claim alarm")
-			continue
-		}
-		if !inserted {
-			// A row exists but IsExist() reported it inactive — a stale
-			// record whose end date has passed but has not been cleaned
-			// up yet. Remove it and claim once more.
-			stillExist, e := dal.Alarm.IsExist(userId, alarm.CreditCode)
-			if e != nil {
-				logger.Error().Stack().Err(e).Msg("recheck alarm existence")
-				continue
-			}
-			if stillExist {
-				continue // claimed by a concurrent invocation in between
-			}
-			if rErr := dal.Alarm.Remove(userId, alarm.CreditCode); rErr != nil {
-				logger.Error().Stack().Err(rErr).Msg("remove stale alarm")
-				continue
-			}
-			inserted, err = dal.Alarm.InsertIfAbsent(alarm)
-			if err != nil {
-				logger.Error().Stack().Err(err).Msg("claim alarm after cleanup")
-				continue
-			}
-			if !inserted {
-				continue // lost the race again, another invocation handles it
-			}
-		}
-
-		msg, err := alarm.ToMessage()
-		if err != nil {
-			logger.Error().Stack().Err(err).Msg("alarm to msg")
-			if rErr := dal.Alarm.Remove(userId, alarm.CreditCode); rErr != nil {
-				logger.Error().Stack().Err(rErr).Msg("rollback alarm after render error")
-			}
-			continue
-		}
-		if _, msgErr := r.ctx.Bot.SendMessage(context.Background(), &bot.SendMessageParams{
-			ChatID:    userId,
-			Text:      msg,
-			ParseMode: models.ParseModeHTML,
-		}); msgErr != nil {
-			logger.Error().Stack().Err(msgErr).Msg("send alarm")
-			// Roll back the claim so the next run can retry this alarm.
-			if rErr := dal.Alarm.Remove(userId, alarm.CreditCode); rErr != nil {
-				logger.Error().Stack().Err(rErr).Msg("rollback alarm after send failure")
-			}
-			continue
-		}
-		// Sent successfully — the record was already persisted by the claim.
+		handles = append(handles, ClaimHandle{
+			Key: alarmKey, // in-process guard, owned by the pipeline
+			Claim: func() (bool, error) {
+				return r.claimAlarm(alarm)
+			},
+			Send: func() error {
+				return r.sendAlarm(alarm)
+			},
+			Rollback: func() error {
+				return dal.Alarm.Remove(userId, alarm.CreditCode)
+			},
+		})
 	}
+	r.pushPipeline.Run(handles)
+}
+
+// claimAlarm claims an alarm via the (user_id, credit_code) unique constraint:
+// fast-path IsExist, then InsertIfAbsent. A conflict with no active record
+// means a stale (expired, not yet cleaned) row — remove it and claim once
+// more. Returns whether this call actually claimed the alarm.
+func (r *InfoProcessor) claimAlarm(alarm *model.Alarm) (bool, error) {
+	logger := r.ctx.Logger
+	userId := alarm.UserID
+
+	isExist, err := dal.Alarm.IsExist(userId, alarm.CreditCode)
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to check alarm existence")
+		return false, err
+	}
+	if isExist {
+		return false, nil
+	}
+
+	inserted, err := dal.Alarm.InsertIfAbsent(alarm)
+	if err != nil {
+		logger.Error().Stack().Err(err).Msg("claim alarm")
+		return false, err
+	}
+	if inserted {
+		return true, nil
+	}
+
+	// A row exists but IsExist() reported it inactive — a stale record whose
+	// end date has passed but has not been cleaned up yet. Remove and retry.
+	stillExist, e := dal.Alarm.IsExist(userId, alarm.CreditCode)
+	if e != nil {
+		logger.Error().Stack().Err(e).Msg("recheck alarm existence")
+		return false, e
+	}
+	if stillExist {
+		return false, nil // claimed by a concurrent invocation in between
+	}
+	if rErr := dal.Alarm.Remove(userId, alarm.CreditCode); rErr != nil {
+		logger.Error().Stack().Err(rErr).Msg("remove stale alarm")
+		return false, rErr
+	}
+	return dal.Alarm.InsertIfAbsent(alarm)
+}
+
+// sendAlarm renders and sends a single alarm message.
+func (r *InfoProcessor) sendAlarm(alarm *model.Alarm) error {
+	logger := r.ctx.Logger
+	msg, err := alarm.ToMessage()
+	if err != nil {
+		logger.Error().Stack().Err(err).Msg("alarm to msg")
+		return err
+	}
+	if _, msgErr := r.ctx.Bot.SendMessage(context.Background(), &bot.SendMessageParams{
+		ChatID:    alarm.UserID,
+		Text:      msg,
+		ParseMode: models.ParseModeHTML,
+	}); msgErr != nil {
+		logger.Error().Stack().Err(msgErr).Msg("send alarm")
+		return msgErr
+	}
+	return nil
 }
 
 func (r *InfoProcessor) ToMessage(project *Project) ([]string, int) {

--- a/pkg/handler/info_processor.go
+++ b/pkg/handler/info_processor.go
@@ -293,6 +293,14 @@ func (r *InfoProcessor) processProjects(pd ProcessData) {
 	}
 	r.pushPipeline.Run(handles)
 
+	// The pre-filter lock was held from shouldSkipProcessing through the
+	// pipeline run; release every claimed URL now so a failed project (whose
+	// history row was rolled back) can be retried by a later run instead of
+	// being permanently skipped by the in-process lock.
+	for _, project := range pending {
+		r.releaseLock(st.userId, project.Pageurl)
+	}
+
 	if len(st.failed) > 1 {
 		if _, err := r.ctx.Bot.SendMessage(context.Background(), &bot.SendMessageParams{
 			ChatID:    st.userId,

--- a/pkg/handler/info_processor.go
+++ b/pkg/handler/info_processor.go
@@ -121,8 +121,16 @@ func (r *InfoProcessor) get(id int64) ProcessData {
 	}
 }
 
-// shouldSkipProcessing checks if a URL is already processed in DB or is being processed,
-// returning true if processing should be skipped
+// shouldSkipProcessing is the render-time pre-filter for project URLs. It is
+// deliberately NOT the authority: its checks (in-process lock + IsUrlExist)
+// only avoid spending CPU on rendering something that is already handled or
+// in flight. The actual at-most-once guarantee comes from the DB claim
+// (InsertIfAbsent) performed later by the PushPipeline — a stale pre-filter
+// pass can only waste a render, never cause a duplicate push.
+//
+// On success (skip=false) the in-process lock is held until the caller
+// finishes with the URL (see releaseLock), so a concurrent invocation in the
+// same process cannot double-render.
 func (r *InfoProcessor) shouldSkipProcessing(userId int64, url string, isForced bool) (skip bool, err error) {
 	lockKey := fmt.Sprintf("%d:%s", userId, url)
 
@@ -166,8 +174,22 @@ const projectContentSem = 5
 func (r *InfoProcessor) Handler(i interface{}) {
 	switch pd := i.(type) {
 	case ProcessData:
-		r.processProjects(pd)
-		r.processAlarms(pd)
+		// Run the two pipelines concurrently so alarm notifications do not
+		// wait behind a large project batch. Both pipelines are safe to run
+		// in parallel: the PushPipeline's keyed lock is concurrent-safe, and
+		// the two handle sets never share a key (projects carry no Key, the
+		// pre-filter lock only guards project URLs).
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			r.processProjects(pd)
+		}()
+		go func() {
+			defer wg.Done()
+			r.processAlarms(pd)
+		}()
+		wg.Wait()
 	}
 }
 

--- a/pkg/handler/info_processor.go
+++ b/pkg/handler/info_processor.go
@@ -40,19 +40,21 @@ type ProcessData struct {
 }
 
 type InfoProcessor struct {
-	ctx        *BotContext
-	pool       *ants.PoolWithFunc
-	crawler    *Crawler
-	urlLocks   *KeyedLock // in-process guard for project URLs
-	alarmLocks *KeyedLock // in-process guard for alarms (userId:CreditCode)
+	ctx          *BotContext
+	pool         *ants.PoolWithFunc
+	crawler      *Crawler
+	urlLocks     *KeyedLock // in-process guard for project URLs
+	alarmLocks   *KeyedLock // in-process guard for alarms (userId:CreditCode)
+	pushPipeline *PushPipeline
 }
 
 func NewInfoProcessor(ctx *BotContext) (*InfoProcessor, error) {
 	processor := &InfoProcessor{
-		ctx:        ctx,
-		crawler:    NewCrawler(ctx),
-		urlLocks:   NewKeyedLock(),
-		alarmLocks: NewKeyedLock(),
+		ctx:          ctx,
+		crawler:      NewCrawler(ctx),
+		urlLocks:     NewKeyedLock(),
+		alarmLocks:   NewKeyedLock(),
+		pushPipeline: NewPushPipeline(),
 	}
 
 	if pool, err := ants.NewPoolWithFunc(poolSize, processor.Handler); err != nil {
@@ -171,29 +173,43 @@ func (r *InfoProcessor) Handler(i interface{}) {
 	}
 }
 
+// projectPushState 汇聚一个用户一轮 project 推送的共享状态，由 PushPipeline
+// 串行消费，因此各字段无需并发保护。
+type projectPushState struct {
+	userId       int64
+	isForced     bool
+	now          time.Time
+	failed       []string
+	filterFailed map[string]*Project
+	processedURL []*model.History
+}
+
 // processProjects handles the project-notice pipeline for one user: filter by
-// keyword rules, render matched content, send messages and record history.
-// The check-send-insert critical section is made atomic by claiming each URL
-// with the DB primary key (user_id, url): only the invocation that actually
-// inserts the history row may send, so concurrent runs — even multiple bot
-// instances sharing the same DB — can never push the same project twice. A
-// fully failed send rolls the claim back so the next run retries. The forced
-// path (/retry) intentionally bypasses the claim so the operator can re-push.
+// keyword rules, render matched content, then push each URL through the
+// PushPipeline skeleton. The DB primary key (user_id, url) acts as a
+// distributed lock: only the invocation that actually inserts the history row
+// may send, so concurrent runs — even multiple bot instances — can never push
+// the same project twice. A fully failed send rolls the claim back so the
+// next run retries. The forced path (/retry) bypasses the claim on purpose.
 func (r *InfoProcessor) processProjects(pd ProcessData) {
 	historyDao := dal.History
 	projects := NewProjects(r.ctx, pd.Projects, pd.ProjectRules).Filter()
-	failed := []string{"failed:"}
-	filterFailed := make(map[string]*Project)
-	userId := pd.UserId
-	var processedURL []*model.History
-	now := time.Now()
-
 	logger := r.ctx.Logger
+	st := &projectPushState{
+		userId:       pd.UserId,
+		isForced:     pd.IsForced,
+		now:          time.Now(),
+		failed:       []string{"failed:"},
+		filterFailed: make(map[string]*Project),
+	}
+
 	// Filter out URLs that were already processed or are being processed by
-	// another worker, so we only render new content.
+	// another worker, so we only render new content. The in-process lock is
+	// held from here until the project has been sent (see shouldSkipProcessing
+	// and sendProject), so the PushPipeline handles carry no Key.
 	var pending []*Project
 	for _, project := range projects {
-		shouldSkip, err := r.shouldSkipProcessing(userId, project.Pageurl, pd.IsForced)
+		shouldSkip, err := r.shouldSkipProcessing(st.userId, project.Pageurl, pd.IsForced)
 		if err != nil {
 			logger.Error().Stack().Err(err).Msg("check url processing failed")
 			continue
@@ -222,94 +238,45 @@ func (r *InfoProcessor) processProjects(pd ProcessData) {
 	}
 	wg.Wait()
 
+	// Build one handle per URL; the pipeline owns claim/send/rollback and the
+	// pre-filter lock already covers the whole lifecycle, so Key is empty.
+	handles := make([]ClaimHandle, 0, len(pending))
 	for j, project := range pending {
 		pageURL := project.Pageurl
-		title := project.Title
-		shortTitle := project.ShortTitle
 		chunks := results[j].chunks
 		total := results[j].total
 		logger.Debug().Msgf("split content to %d parts", total)
 
-		// Wrap each URL in a closure so the in-process lock is released by
-		// defer on every exit path — including future ones — instead of
-		// relying on each branch remembering to call releaseLock.
-		func() {
-			defer r.releaseLock(userId, pageURL)
-
-			// Claim the URL with the DB primary key acting as a distributed
-			// lock. Only the caller that actually created the history row
-			// proceeds to send; any concurrent caller (even from another bot
-			// instance) gets RowsAffected == 0 and skips. The forced path is
-			// exempt so /retry can deliberately re-push already-seen projects.
-			if !pd.IsForced {
-				claimed, err := historyDao.InsertIfAbsent(&model.History{
-					UserID:        userId,
+		handles = append(handles, ClaimHandle{
+			Claim: func() (bool, error) {
+				if st.isForced {
+					return true, nil // forced path re-pushes without claiming
+				}
+				return historyDao.InsertIfAbsent(&model.History{
+					UserID:        st.userId,
 					URL:           pageURL,
-					Title:         shortTitle,
-					UpdatedAt:     now,
+					Title:         project.ShortTitle,
+					UpdatedAt:     st.now,
 					HasTenderCode: btoi(project.HasTenderCode),
 				})
-				if err != nil {
-					logger.Error().Stack().Err(err).Msg("claim project")
-					return
+			},
+			Send: func() error {
+				return r.sendProject(st, project, chunks, total)
+			},
+			Rollback: func() error {
+				if st.isForced {
+					return nil
 				}
-				if !claimed {
-					logger.Debug().Msgf("URL %s claimed by another invocation, skip", shortTitle)
-					return
-				}
-			}
-
-			// only save all parts failed to the failed list
-			isSuccessful := false
-			for idx, chunk := range chunks {
-				if _, errSend := r.ctx.Bot.SendMessage(context.Background(), &bot.SendMessageParams{
-					ChatID:    userId,
-					Text:      chunk,
-					ParseMode: models.ParseModeHTML,
-				}); errSend != nil {
-					if !isSuccessful {
-						if _, ok := filterFailed[pageURL]; !ok {
-							filterFailed[pageURL] = project
-							failed = append(failed, fmt.Sprintf("%d. <b>[%s]</b> <a href=\"%s\">%s</a>",
-								len(failed), project.Keyword, pageURL, title))
-						}
-					}
-					logger.Error().Stack().Err(errSend).Msgf("content: %s", chunk)
-					if idx == 0 {
-						// Nothing was delivered: roll back the claim so the
-						// next run can retry this project.
-						if !pd.IsForced {
-							if rErr := historyDao.Remove(userId, pageURL); rErr != nil {
-								logger.Error().Stack().Err(rErr).Msg("rollback project claim")
-							}
-						}
-						return
-					}
-				} else {
-					isSuccessful = true
-					logger.Info().Msgf("notify: %s[%s]-%d", shortTitle, project.OpenTenderCode, idx)
-				}
-				time.Sleep(500 * time.Millisecond)
-			}
-
-			if isSuccessful && total > 0 && pd.IsForced {
-				// Forced path bypasses the claim, so persist history here.
-				// Normal path already persisted the row at claim time.
-				processedURL = append(processedURL, &model.History{
-					UserID:        userId,
-					URL:           pageURL,
-					Title:         shortTitle,
-					UpdatedAt:     now,
-					HasTenderCode: btoi(project.HasTenderCode),
-				})
-			}
-		}()
+				return historyDao.Remove(st.userId, pageURL)
+			},
+		})
 	}
+	r.pushPipeline.Run(handles)
 
-	if len(failed) > 1 {
+	if len(st.failed) > 1 {
 		if _, err := r.ctx.Bot.SendMessage(context.Background(), &bot.SendMessageParams{
-			ChatID:    userId,
-			Text:      strings.Join(failed, "\n"),
+			ChatID:    st.userId,
+			Text:      strings.Join(st.failed, "\n"),
 			ParseMode: models.ParseModeHTML,
 		}); err != nil {
 			logger.Error().Stack().Err(err).Msg("")
@@ -317,13 +284,13 @@ func (r *InfoProcessor) processProjects(pd ProcessData) {
 			// The failure summary reached the user, so persist the failed
 			// URLs to avoid re-pushing them on every run. Their claims (if
 			// any) were already rolled back when the first chunk failed.
-			for _, v := range filterFailed {
+			for _, v := range st.filterFailed {
 				if _, err := historyDao.InsertIfAbsent(&model.History{
-					UserID:        userId,
+					UserID:        st.userId,
 					URL:           v.Pageurl,
 					Title:         v.ShortTitle,
 					HasTenderCode: btoi(v.HasTenderCode),
-					UpdatedAt:     now,
+					UpdatedAt:     st.now,
 				}); err != nil {
 					logger.Error().Stack().Err(err).Msg("")
 				}
@@ -331,12 +298,60 @@ func (r *InfoProcessor) processProjects(pd ProcessData) {
 		}
 	}
 
-	if len(processedURL) > 0 {
-		if err := historyDao.Insert(processedURL); err != nil {
+	if len(st.processedURL) > 0 {
+		if err := historyDao.Insert(st.processedURL); err != nil {
 			logger.Error().Stack().Err(err).Msg("")
 		}
 	}
+}
 
+// sendProject sends a project's chunked message, collecting failures for the
+// summary. It returns an error only when the very first chunk failed (nothing
+// was delivered), which makes the PushPipeline roll back the claim so the
+// next run can retry.
+func (r *InfoProcessor) sendProject(st *projectPushState, project *Project, chunks []string, total int) error {
+	logger := r.ctx.Logger
+	pageURL := project.Pageurl
+	title := project.Title
+	shortTitle := project.ShortTitle
+
+	isSuccessful := false
+	for idx, chunk := range chunks {
+		if _, errSend := r.ctx.Bot.SendMessage(context.Background(), &bot.SendMessageParams{
+			ChatID:    st.userId,
+			Text:      chunk,
+			ParseMode: models.ParseModeHTML,
+		}); errSend != nil {
+			if !isSuccessful {
+				if _, ok := st.filterFailed[pageURL]; !ok {
+					st.filterFailed[pageURL] = project
+					st.failed = append(st.failed, fmt.Sprintf("%d. <b>[%s]</b> <a href=\"%s\">%s</a>",
+						len(st.failed), project.Keyword, pageURL, title))
+				}
+			}
+			logger.Error().Stack().Err(errSend).Msgf("content: %s", chunk)
+			if idx == 0 {
+				return errSend // nothing delivered → pipeline rolls back
+			}
+		} else {
+			isSuccessful = true
+			logger.Info().Msgf("notify: %s[%s]-%d", shortTitle, project.OpenTenderCode, idx)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	if isSuccessful && total > 0 && st.isForced {
+		// Forced path bypasses the claim, so persist history here.
+		// Normal path already persisted the row at claim time.
+		st.processedURL = append(st.processedURL, &model.History{
+			UserID:        st.userId,
+			URL:           pageURL,
+			Title:         shortTitle,
+			UpdatedAt:     st.now,
+			HasTenderCode: btoi(project.HasTenderCode),
+		})
+	}
+	return nil
 }
 
 // processAlarms handles the alarm-notice pipeline for one user: dedupe alarms

--- a/pkg/handler/info_processor.go
+++ b/pkg/handler/info_processor.go
@@ -224,9 +224,7 @@ func (r *InfoProcessor) processProjects(pd ProcessData) {
 	}
 
 	// Filter out URLs that were already processed or are being processed by
-	// another worker, so we only render new content. The in-process lock is
-	// held from here until the project has been sent (see shouldSkipProcessing
-	// and sendProject), so the PushPipeline handles carry no Key.
+	// another worker, so we only render new content.
 	var pending []*Project
 	for _, project := range projects {
 		shouldSkip, err := r.shouldSkipProcessing(st.userId, project.Pageurl, pd.IsForced)
@@ -258,8 +256,8 @@ func (r *InfoProcessor) processProjects(pd ProcessData) {
 	}
 	wg.Wait()
 
-	// Build one handle per URL; the pipeline owns claim/send/rollback and the
-	// pre-filter lock already covers the whole lifecycle, so Key is empty.
+	// Handles carry no Key: the pre-filter lock already covers the whole
+	// render+send lifecycle.
 	handles := make([]ClaimHandle, 0, len(pending))
 	for j, project := range pending {
 		pageURL := project.Pageurl

--- a/pkg/handler/push_pipeline.go
+++ b/pkg/handler/push_pipeline.go
@@ -1,0 +1,52 @@
+package handler
+
+// ClaimHandle 定义一条可抢占推送的最小单元。
+//
+// 处理骨架固定为：内存锁 → DB 抢占 → 发送 → 失败回滚。
+// 管线只关心骨架，具体业务（唯一键组成、发送内容、回滚语义）由回调提供。
+type ClaimHandle struct {
+	// Key 是进程内锁（KeyedLock）的键；为空表示调用方已自行管理并发
+	//（例如 projects 的预筛锁已覆盖整个渲染+发送生命周期）。
+	Key string
+	// Claim 执行 DB 原子抢占（InsertIfAbsent），返回是否抢到。
+	// 只有真正抢到的调用才允许发送。
+	Claim func() (bool, error)
+	// Send 执行发送；返回 error 表示发送失败，会触发 Rollback 回滚。
+	Send func() error
+	// Rollback 在发送失败时回滚抢占（Remove），供下一轮重试。
+	Rollback func() error
+}
+
+// PushPipeline 串行处理一批可抢占推送。同一进程内相同 Key 的 handle 只会
+// 被处理一次；跨实例的互斥由 Claim 背后的 DB 唯一约束保证。
+type PushPipeline struct {
+	locks *KeyedLock
+}
+
+// NewPushPipeline 返回一个空的 PushPipeline。
+func NewPushPipeline() *PushPipeline {
+	return &PushPipeline{locks: NewKeyedLock()}
+}
+
+// Run 依次处理 handles。单个 handle 的失败不影响其余 handle。
+func (p *PushPipeline) Run(handles []ClaimHandle) {
+	for _, h := range handles {
+		func() {
+			if h.Key != "" {
+				if !p.locks.TryLock(h.Key) {
+					return // 同进程内另一调用正在处理，跳过
+				}
+				defer p.locks.Unlock(h.Key)
+			}
+
+			claimed, err := h.Claim()
+			if err != nil || !claimed {
+				return // 抢占失败：已存在或出错，让给别的调用/下一轮
+			}
+
+			if err := h.Send(); err != nil {
+				_ = h.Rollback() // 发送失败，回滚抢占供下一轮重试
+			}
+		}()
+	}
+}

--- a/pkg/handler/push_pipeline_test.go
+++ b/pkg/handler/push_pipeline_test.go
@@ -1,0 +1,107 @@
+package handler
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+)
+
+// TestPushPipelineClaimAndSend verifies the pipeline skeleton: only the handle
+// that claims the resource proceeds to send; a failed send triggers rollback.
+func TestPushPipelineClaimAndSend(t *testing.T) {
+	p := NewPushPipeline()
+
+	var claimed, sent, rolledBack int32
+	handles := []ClaimHandle{
+		{
+			Key: "a",
+			Claim: func() (bool, error) {
+				atomic.AddInt32(&claimed, 1)
+				return true, nil
+			},
+			Send: func() error {
+				atomic.AddInt32(&sent, 1)
+				return errors.New("send failed")
+			},
+			Rollback: func() error {
+				atomic.AddInt32(&rolledBack, 1)
+				return nil
+			},
+		},
+		{
+			Key: "b",
+			Claim: func() (bool, error) {
+				atomic.AddInt32(&claimed, 1)
+				return false, nil // lost the claim, must not send
+			},
+			Send: func() error {
+				atomic.AddInt32(&sent, 1)
+				return nil
+			},
+		},
+	}
+
+	p.Run(handles)
+
+	if claimed != 2 {
+		t.Errorf("expected both handles to attempt claim, got %d", claimed)
+	}
+	if sent != 1 {
+		t.Errorf("expected exactly 1 send, got %d", sent)
+	}
+	if rolledBack != 1 {
+		t.Errorf("expected rollback for the failed send, got %d", rolledBack)
+	}
+}
+
+// TestPushPipelineKeyLock verifies that a handle whose in-process Key is
+// already held is skipped entirely (no claim, no send).
+func TestPushPipelineKeyLock(t *testing.T) {
+	p := NewPushPipeline()
+
+	// Pre-hold the key, simulating another invocation currently processing it.
+	if !p.locks.TryLock("same") {
+		t.Fatal("expected to hold the key")
+	}
+
+	var sent int32
+	p.Run([]ClaimHandle{{
+		Key: "same",
+		Claim: func() (bool, error) {
+			t.Error("claim must not run while the key is held")
+			return true, nil
+		},
+		Send: func() error {
+			atomic.AddInt32(&sent, 1)
+			return nil
+		},
+	}})
+
+	if sent != 0 {
+		t.Fatalf("expected the handle to be skipped, got %d sends", sent)
+	}
+	p.locks.Unlock("same")
+}
+
+// TestPushPipelineNoKeySkipsLock verifies that a handle without a Key is not
+// gated by the in-process lock (the caller manages concurrency itself).
+func TestPushPipelineNoKeySkipsLock(t *testing.T) {
+	p := NewPushPipeline()
+
+	var sent int32
+	handles := make([]ClaimHandle, 0, 3)
+	for i := 0; i < 3; i++ {
+		handles = append(handles, ClaimHandle{
+			Claim: func() (bool, error) { return true, nil },
+			Send: func() error {
+				atomic.AddInt32(&sent, 1)
+				return nil
+			},
+		})
+	}
+	p.Run(handles)
+
+	if sent != 3 {
+		t.Fatalf("expected all 3 handles to send without a Key, got %d", sent)
+	}
+}


### PR DESCRIPTION
## 概述

按重构方案（`REFACTOR_PLAN.md`）将 alarm/project 两条推送管线收敛到共享的 `PushPipeline` 骨架，**全部 5 个 Step 已落地**，不改变任何外部行为。

## 变更（6 个 commit）

1. **`refactor: extract PushPipeline skeleton`** — 新增 `ClaimHandle`（Key/Claim/Send/Rollback 四回调）+ `PushPipeline.Run`，统一处理锁 → DB 抢占 → 发送 → 失败回滚骨架。
2. **`refactor: slim processProjects`** — 从 ~160 行降到"预筛 + 并发渲染 + 构建 handles"骨架；多 chunk 发送/失败收集抽到 `sendProject`；共享状态收进 `projectPushState`。
3. **`refactor: slim processAlarms`** — 过期占位重抢收进 `claimAlarm`，渲染发送收进 `sendAlarm`；删除冗余 `alarmLocks` 字段和重复测试（净 -149 行）。
4. **`docs: mark refactor plan Steps 1-3 done`**
5. **`refactor: clarify pre-filter/claim roles and run pipelines concurrently`** — Step 4：明确 `shouldSkipProcessing` 只是渲染期预筛，权威是 DB claim（预筛过期只浪费渲染、绝不重复推送）；Step 5：`Handler` 并行运行 projects/alarms 两条管线，告警不再等大项目批次。
6. **`docs: mark refactor plan all steps done`**

## 行为不变性

- projects 的多 chunk 部分成功 / failed 汇总 / `/retry` 强制模式（IsForced 绕过 claim）保留
- alarms 的过期记录占位重抢保留
- DB 原子抢占语义不变（跨实例防重）
- 并行化安全：两管线 handle 不共享锁 Key（projects 无 Key；预筛锁只管项目 URL）

## 验证

- `go build` / `go vet` 全绿
- `go test ./pkg/... -race`：仅 3 个**预先存在**的失败（`Test_alarmQuery`、`Test_historyQuery`、`TestMergeLines`，干净 HEAD 上同样失败）
- PushPipeline 单元测试：claim 失败不发送、发送失败触发回滚、Key 占用跳过、无 Key 不锁